### PR TITLE
Add option to use legacy planning metric definition 

### DIFF
--- a/projects/configs/stage1_track_map/base_track_map.py
+++ b/projects/configs/stage1_track_map/base_track_map.py
@@ -63,6 +63,10 @@ occ_n_future_max = max([occ_n_future, occ_n_future_plan])
 ### planning ###
 planning_steps = 6
 use_col_optim = True
+# there exists multiple interpretations of the planning metric, where it differs between uniad and stp3/vad
+# uniad: computed at a particular time (e.g., L2 distance between the predicted and ground truth future trajectory at time 3.0s)
+# stp3: computed as the average up to a particular time (e.g., average L2 distance between the predicted and ground truth future trajectory up to 3.0s)
+planning_metric_strategy = "uniad"  # uniad or stp3
 
 ### Occ args ### 
 occflow_grid_conf = {
@@ -570,7 +574,11 @@ lr_config = dict(
     min_lr_ratio=1e-3,
 )
 total_epochs = 6
-evaluation = dict(interval=6, pipeline=test_pipeline)
+evaluation = dict(
+    interval=6,
+    pipeline=test_pipeline,
+    planning_evaluation_strategy=planning_evaluation_strategy,
+)
 runner = dict(type="EpochBasedRunner", max_epochs=total_epochs)
 log_config = dict(
     interval=10, hooks=[dict(type="TextLoggerHook"), dict(type="TensorboardLoggerHook")]

--- a/projects/configs/stage2_e2e/base_e2e.py
+++ b/projects/configs/stage2_e2e/base_e2e.py
@@ -55,6 +55,10 @@ occ_n_future_max = max([occ_n_future, occ_n_future_plan])
 ### planning ###
 planning_steps = 6
 use_col_optim = True
+# there exists multiple interpretations of the planning metric, where it differs between uniad and stp3/vad
+# uniad: computed at a particular time (e.g., L2 distance between the predicted and ground truth future trajectory at time 3.0s)
+# stp3: computed as the average up to a particular time (e.g., average L2 distance between the predicted and ground truth future trajectory up to 3.0s)
+planning_evaluation_strategy = "uniad"  # uniad or stp3
 
 ### Occ args ### 
 occflow_grid_conf = {
@@ -685,7 +689,11 @@ lr_config = dict(
     min_lr_ratio=1e-3,
 )
 total_epochs = 20
-evaluation = dict(interval=4, pipeline=test_pipeline)
+evaluation = dict(
+    interval=4,
+    pipeline=test_pipeline,
+    planning_evaluation_strategy=planning_evaluation_strategy,
+)
 runner = dict(type="EpochBasedRunner", max_epochs=total_epochs)
 log_config = dict(
     interval=10, hooks=[dict(type="TextLoggerHook"), dict(type="TensorboardLoggerHook")]

--- a/projects/mmdet3d_plugin/datasets/nuscenes_e2e_dataset.py
+++ b/projects/mmdet3d_plugin/datasets/nuscenes_e2e_dataset.py
@@ -981,7 +981,8 @@ class NuScenesE2EDataset(NuScenesDataset):
                  result_names=['pts_bbox'],
                  show=False,
                  out_dir=None,
-                 pipeline=None):
+                 pipeline=None,
+                 planning_evaluation_strategy="uniad"):
         """Evaluation in nuScenes protocol.
         Args:
             results (list[dict]): Testing results of the dataset.
@@ -1024,6 +1025,7 @@ class NuScenesE2EDataset(NuScenesDataset):
             if 'planning_results_computed' in results.keys():
                 planning_results_computed = results['planning_results_computed']
                 planning_tab = PrettyTable()
+                planning_tab.title = f"{planning_evaluation_strategy}'s definition planning metrics"
                 planning_tab.field_names = [
                     "metrics", "0.5s", "1.0s", "1.5s", "2.0s", "2.5s", "3.0s"]
                 for key in planning_results_computed.keys():
@@ -1031,7 +1033,14 @@ class NuScenesE2EDataset(NuScenesDataset):
                     row_value = []
                     row_value.append(key)
                     for i in range(len(value)):
-                        row_value.append('%.4f' % float(value[i]))
+                        if planning_evaluation_strategy == "stp3":
+                            row_value.append("%.4f" % float(value[: i + 1].mean()))
+                        elif planning_evaluation_strategy == "uniad":
+                            row_value.append("%.4f" % float(value[i]))
+                        else:
+                            raise ValueError(
+                                "planning_evaluation_strategy should be uniad or spt3"
+                            )
                     planning_tab.add_row(row_value)
                 print(planning_tab)
             results = results['bbox_results']  # get bbox_results


### PR DESCRIPTION
As described in #166, there is a discrepancy between how planning metrics (L2 and collision rate) are computed in this repo vs previous works, such as [VAD](https://github.com/hustvl/VAD) and [ST-P3](https://github.com/OpenDriveLab/ST-P3). 

However, in the paper, these values are compared in the same table, leading to confusion. This PR enables computation of the UniAD metrics using the legacy definition used by VAD/ST-P3, making comparison easier. However, it still defaults to the "original" UniAD way of evaluating. This results in a ranking shift when comparing the methods, see the table below

| Method | L2 1s (m) | L2 2s (m) | L2 3s (m) | CR 1s (%) | CR 2s (%) | CR 3s (%) |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| ST-P3 | 1.33 | 2.11 | 2.90 | 0.23 | 0.62 | 1.27 |
| UniAD (your current metric) | 0.51 | 0.98 | 1.65 | 0.10 | 0.15 | 0.61 |
| UniAD (legacy ST-P3 metric) | 0.42 | **0.64** | **0.91** | **0.07** | **0.10** | **0.22** |
| VAD-Tiny | 0.46 | 0.76 | 1.12 | 0.21 | 0.35 | 0.58 |
| VAD-Base | **0.41** | 0.70 | 1.05 | **0.07** | 0.17 | 0.41 |

