### PR TITLE
Add planner-only group-relative LoRA post-training

### DIFF
--- a/docs/PLANNER_GRPO_LORA.md
+++ b/docs/PLANNER_GRPO_LORA.md
@@ -1,0 +1,44 @@
+# Planner-only group-relative LoRA post-training
+
+This optional path freezes stage-2 UniAD and updates only planning-head LoRA
+parameters plus a learned diagonal Gaussian `log_std`. The original
+`PlanningHeadSingleMode` path is unchanged.
+
+The policy samples six 2D displacement increments per rollout and converts
+them to waypoints with `cumsum`. Training uses group-normalized open-loop
+ADE/FDE/comfort rewards, an exact non-negative KL to the LoRA-disabled SFT
+planner, and an auxiliary mean-path ADE loss. Inference always deploys the
+deterministic mean path.
+
+```bash
+python tools/create_data.py nuscenes \
+  --root-path ./data/nuscenes --canbus ./data/nuscenes \
+  --version v1.0-mini --out-dir ./data/infos \
+  --extra-tag nuscenes
+
+python tools/train.py \
+  projects/configs/planner_posttrain/uniad_planner_grpo_lora.py \
+  --work-dir work_dirs/planner_grpo_lora
+```
+
+## Preliminary v1.0-mini evidence
+
+Hardware: RTX 4060 Ti 16 GB, batch size 1, FP32. Metrics are open-loop only.
+
+| Measurement | Result |
+|---|---:|
+| Rollout sample-best minFDE (best logged frame) | 0.052 m |
+| Deterministic mean-path ADE (12 frames) | 3.60 m mean / 0.98 m median |
+| Deterministic mean-path FDE (12 frames) | 6.83 m mean |
+| Mean-path worst case | 19.50 m |
+
+These numbers came from the earlier auxiliary-fit campaign. Its audit found
+that the same-forward PPO ratio was always 1.0 and its reparameterized action
+made the reported GRPO term ineffective. Therefore they show planner-only
+LoRA/auxiliary fitting feasibility, not a causal GRPO gain. This patch removes
+that defect by scoring detached actions and tests for non-zero policy-mean
+gradients. A fresh full mini comparison is still required.
+
+Sample-best rollout ADE/FDE and deterministic mean-path ADE/FDE are different
+metrics and must not be compared as if they were the same estimator. No
+trainval planning result or closed-loop collision result is claimed.

--- a/projects/configs/planner_posttrain/uniad_planner_grpo_lora.py
+++ b/projects/configs/planner_posttrain/uniad_planner_grpo_lora.py
@@ -1,0 +1,33 @@
+_base_ = ['../stage2_e2e/base_e2e.py']
+
+# The info files below must be generated from nuScenes v1.0-mini when
+# reproducing the preliminary experiment in docs/PLANNER_GRPO_LORA.md.
+data = dict(samples_per_gpu=1, workers_per_gpu=2)
+
+model = dict(
+    planner_posttrain_only=True,
+    planning_head=dict(
+        type='PlanningHeadGRPO',
+        loss_collision=[],
+        use_col_optim=False,
+        grpo=dict(
+            num_samples=6,
+            kl_weight=0.01,
+            aux_weight=1.0,
+            lora_rank=8,
+            lora_alpha=16.0,
+            init_log_std=-1.5,
+            ade_weight=1.0,
+            fde_weight=1.0,
+            comfort_weight=0.1,
+        ),
+    ),
+)
+
+optimizer = dict(type='AdamW', lr=1e-4, weight_decay=0.0)
+optimizer_config = dict(grad_clip=dict(max_norm=5.0, norm_type=2))
+load_from = 'ckpts/uniad_base_e2e.pth'
+total_epochs = 3
+runner = dict(type='EpochBasedRunner', max_epochs=total_epochs)
+checkpoint_config = dict(interval=1)
+find_unused_parameters = True

--- a/projects/mmdet3d_plugin/losses/__init__.py
+++ b/projects/mmdet3d_plugin/losses/__init__.py
@@ -3,6 +3,7 @@ from .mtp_loss import MTPLoss
 from .occflow_loss import *
 from .traj_loss import TrajLoss
 from .planning_loss import PlanningLoss, CollisionLoss
+from .grpo_loss import PlannerReward
 from .dice_loss import DiceLoss
 
 __all__ = [
@@ -10,5 +11,5 @@ __all__ = [
     'DiceLoss',
     'FieryBinarySegmentationLoss', 'DiceLossWithMasks',
     'TrajLoss',
-    'PlanningLoss', 'CollisionLoss'
+    'PlanningLoss', 'CollisionLoss', 'PlannerReward'
 ]

--- a/projects/mmdet3d_plugin/losses/grpo_loss.py
+++ b/projects/mmdet3d_plugin/losses/grpo_loss.py
@@ -32,15 +32,18 @@ def masked_ade(trajectories, target, mask):
 
 def masked_fde(trajectories, target, mask):
     batch = torch.arange(trajectories.shape[0], device=trajectories.device)
-    last = mask.long().sum(-1).clamp_min(1) - 1
-    return torch.norm(
+    valid_count = mask.long().sum(-1)
+    last = (valid_count - 1).clamp_min(0)
+    fde = torch.norm(
         trajectories[batch, :, last] - target[batch, last, None], dim=-1)
+    return torch.where(valid_count[:, None] > 0, fde, torch.zeros_like(fde))
 
 
 def comfort_penalty(trajectories):
     if trajectories.shape[-2] < 4:
         return trajectories.new_zeros(trajectories.shape[:2])
-    velocity = torch.diff(trajectories, dim=-2, prepend=trajectories[..., :1, :])
+    origin = torch.zeros_like(trajectories[..., :1, :])
+    velocity = torch.diff(trajectories, dim=-2, prepend=origin)
     acceleration = torch.diff(velocity, dim=-2)
     jerk = torch.diff(acceleration, dim=-2)
     return jerk.square().mean(dim=(-1, -2))

--- a/projects/mmdet3d_plugin/losses/grpo_loss.py
+++ b/projects/mmdet3d_plugin/losses/grpo_loss.py
@@ -1,0 +1,113 @@
+#---------------------------------------------------------------------------------#
+# UniAD: Planning-oriented Autonomous Driving (https://arxiv.org/abs/2212.10156)  #
+# Source code: https://github.com/OpenDriveLab/UniAD                              #
+# Copyright (c) OpenDriveLab. All rights reserved.                                #
+#---------------------------------------------------------------------------------#
+
+import math
+
+import torch
+import torch.nn as nn
+from mmdet.models import LOSSES
+
+
+LOG_2PI = math.log(2.0 * math.pi)
+
+
+def planning_target(sdc_planning, sdc_planning_mask, planning_steps):
+    target = sdc_planning[..., :planning_steps, :2]
+    mask = torch.any(sdc_planning_mask[..., :planning_steps], dim=-1)
+    if target.dim() == 4:
+        target = target[:, 0]
+    if mask.dim() == 3:
+        mask = mask[:, 0]
+    return target, mask
+
+
+def masked_ade(trajectories, target, mask):
+    error = torch.norm(trajectories - target[:, None], dim=-1)
+    valid = mask[:, None].to(error.dtype)
+    return (error * valid).sum(-1) / valid.sum(-1).clamp_min(1.0)
+
+
+def masked_fde(trajectories, target, mask):
+    batch = torch.arange(trajectories.shape[0], device=trajectories.device)
+    last = mask.long().sum(-1).clamp_min(1) - 1
+    return torch.norm(
+        trajectories[batch, :, last] - target[batch, last, None], dim=-1)
+
+
+def comfort_penalty(trajectories):
+    if trajectories.shape[-2] < 4:
+        return trajectories.new_zeros(trajectories.shape[:2])
+    velocity = torch.diff(trajectories, dim=-2, prepend=trajectories[..., :1, :])
+    acceleration = torch.diff(velocity, dim=-2)
+    jerk = torch.diff(acceleration, dim=-2)
+    return jerk.square().mean(dim=(-1, -2))
+
+
+@LOSSES.register_module()
+class PlannerReward(nn.Module):
+    """Open-loop trajectory reward used by the group-relative objective."""
+
+    def __init__(self, planning_steps=6, ade_weight=1.0, fde_weight=1.0,
+                 comfort_weight=0.1):
+        super().__init__()
+        self.planning_steps = planning_steps
+        self.ade_weight = ade_weight
+        self.fde_weight = fde_weight
+        self.comfort_weight = comfort_weight
+
+    def forward(self, trajectories, sdc_planning, sdc_planning_mask):
+        target, mask = planning_target(
+            sdc_planning, sdc_planning_mask, self.planning_steps)
+        ade = masked_ade(trajectories, target, mask)
+        fde = masked_fde(trajectories, target, mask)
+        comfort = comfort_penalty(trajectories)
+        reward = -(self.ade_weight * ade + self.fde_weight * fde
+                   + self.comfort_weight * comfort)
+        metrics = dict(
+            reward=reward.mean(),
+            reward_std=reward.std(dim=1, unbiased=False).mean(),
+            sample_ade=ade.mean(),
+            sample_fde=fde.mean(),
+            sample_best_ade=ade.min(dim=1).values.mean(),
+            sample_best_fde=fde.min(dim=1).values.mean(),
+            comfort=comfort.mean(),
+        )
+        return reward, metrics
+
+
+def compute_group_advantages(reward, eps=1e-8):
+    """Normalize rewards within each rollout group and stop reward gradients."""
+    reward = reward.detach()
+    centered = reward - reward.mean(dim=1, keepdim=True)
+    scale = reward.std(dim=1, keepdim=True, unbiased=False)
+    return centered / (scale + eps)
+
+
+def gaussian_log_prob(actions, mean, log_std, min_log_std=-5.0,
+                      max_log_std=2.0):
+    """Log probability of [B, G, T, 2] actions under a diagonal Gaussian."""
+    log_std = log_std.clamp(min_log_std, max_log_std)
+    while mean.dim() < actions.dim():
+        mean = mean.unsqueeze(1)
+    log_std = log_std.view(1, 1, *log_std.shape)
+    log_prob = -0.5 * (
+        ((actions - mean) / log_std.exp()).square()
+        + 2.0 * log_std + LOG_2PI)
+    return log_prob.sum(dim=(-1, -2))
+
+
+def group_relative_policy_loss(log_prob, advantages):
+    """Single-update GRPO score-function objective (no stale PPO ratio)."""
+    if log_prob.shape != advantages.shape:
+        raise ValueError('log_prob and advantages must have the same shape')
+    return -(log_prob * advantages.detach()).mean()
+
+
+def diagonal_gaussian_kl(mean, reference_mean, log_std):
+    """Exact KL to a reference Gaussian with the same diagonal variance."""
+    inverse_variance = torch.exp(-2.0 * log_std.clamp(-5.0, 2.0))
+    return 0.5 * ((mean - reference_mean).square()
+                  * inverse_variance).sum(dim=(-1, -2)).mean()

--- a/projects/mmdet3d_plugin/models/utils/__init__.py
+++ b/projects/mmdet3d_plugin/models/utils/__init__.py
@@ -2,3 +2,4 @@
 from .bricks import run_time
 from .grid_mask import GridMask
 from .visual import save_tensor
+from .lora import LoRALinear

--- a/projects/mmdet3d_plugin/models/utils/lora.py
+++ b/projects/mmdet3d_plugin/models/utils/lora.py
@@ -1,0 +1,114 @@
+#---------------------------------------------------------------------------------#
+# UniAD: Planning-oriented Autonomous Driving (https://arxiv.org/abs/2212.10156)  #
+# Source code: https://github.com/OpenDriveLab/UniAD                              #
+# Copyright (c) OpenDriveLab. All rights reserved.                                #
+#---------------------------------------------------------------------------------#
+
+import torch
+import torch.nn as nn
+
+
+class LoRALinear(nn.Module):
+    """A frozen linear layer with an optional low-rank update."""
+
+    def __init__(self, base, rank=8, alpha=16.0, dropout=0.0):
+        super().__init__()
+        if not isinstance(base, nn.Linear):
+            raise TypeError('base must be an nn.Linear')
+        if rank <= 0:
+            raise ValueError('rank must be positive')
+
+        self.base = base
+        self.rank = rank
+        self.scale = alpha / rank
+        self.enabled = True
+        self.dropout = nn.Dropout(dropout) if dropout else nn.Identity()
+        self.lora_A = nn.Parameter(torch.empty(rank, base.in_features))
+        self.lora_B = nn.Parameter(torch.zeros(base.out_features, rank))
+        nn.init.kaiming_uniform_(self.lora_A, a=5 ** 0.5)
+
+        self.base.requires_grad_(False)
+
+    @property
+    def weight(self):
+        if not self.enabled:
+            return self.base.weight
+        # MultiheadAttention consumes out_proj.weight directly instead of
+        # calling out_proj.forward, so expose the merged weight here as well.
+        return self.base.weight + self.scale * (self.lora_B @ self.lora_A)
+
+    @property
+    def bias(self):
+        return self.base.bias
+
+    @property
+    def in_features(self):
+        return self.base.in_features
+
+    @property
+    def out_features(self):
+        return self.base.out_features
+
+    def forward(self, inputs):
+        output = self.base(inputs)
+        if self.enabled:
+            update = self.dropout(inputs) @ self.lora_A.t() @ self.lora_B.t()
+            output = output + self.scale * update
+        return output
+
+    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        """Accept the original nn.Linear checkpoint key layout."""
+        for name in ('weight', 'bias'):
+            legacy_key = prefix + name
+            base_key = prefix + 'base.' + name
+            if legacy_key in state_dict and base_key not in state_dict:
+                state_dict[base_key] = state_dict.pop(legacy_key)
+        super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
+
+
+def _replace_linear(parent, name, rank, alpha, dropout):
+    module = LoRALinear(
+        getattr(parent, name), rank=rank, alpha=alpha, dropout=dropout)
+    setattr(parent, name, module)
+    return module
+
+
+def apply_lora_to_planning_head(head, rank=8, alpha=16.0, dropout=0.0):
+    """Mount LoRA on planner projections, leaving the BEV adapter frozen."""
+    modules = []
+
+    if isinstance(head.mlp_fuser[0], nn.Linear):
+        modules.append(_replace_linear(
+            head.mlp_fuser, '0', rank, alpha, dropout))
+
+    for layer in head.attn_module.layers:
+        for name in ('linear1', 'linear2'):
+            if isinstance(getattr(layer, name), nn.Linear):
+                modules.append(_replace_linear(
+                    layer, name, rank, alpha, dropout))
+        for name in ('self_attn', 'multihead_attn'):
+            attention = getattr(layer, name, None)
+            if attention is not None and isinstance(attention.out_proj, nn.Linear):
+                modules.append(_replace_linear(
+                    attention, 'out_proj', rank, alpha, 0.0))
+
+    for index, module in enumerate(head.reg_branch):
+        if isinstance(module, nn.Linear):
+            modules.append(_replace_linear(
+                head.reg_branch, str(index), rank, alpha, dropout))
+
+    # The modules are already registered at their original locations.  Keep a
+    # plain list here to avoid duplicate state-dict keys.
+    head._lora_modules = modules
+    return modules
+
+
+def set_lora_enabled(head, enabled):
+    for module in getattr(head, '_lora_modules', []):
+        module.enabled = enabled
+
+
+def lora_parameters(head):
+    for module in getattr(head, '_lora_modules', []):
+        yield module.lora_A
+        yield module.lora_B

--- a/projects/mmdet3d_plugin/uniad/dense_heads/__init__.py
+++ b/projects/mmdet3d_plugin/uniad/dense_heads/__init__.py
@@ -3,4 +3,5 @@ from .panseg_head import PansegformerHead
 from .motion_head import MotionHead
 from .occ_head import OccHead
 from .planning_head import PlanningHeadSingleMode
+from .planning_head_grpo import PlanningHeadGRPO
 from .bevformer_head import BEVFormerHead

--- a/projects/mmdet3d_plugin/uniad/dense_heads/planning_head_grpo.py
+++ b/projects/mmdet3d_plugin/uniad/dense_heads/planning_head_grpo.py
@@ -1,0 +1,196 @@
+#---------------------------------------------------------------------------------#
+# UniAD: Planning-oriented Autonomous Driving (https://arxiv.org/abs/2212.10156)  #
+# Source code: https://github.com/OpenDriveLab/UniAD                              #
+# Copyright (c) OpenDriveLab. All rights reserved.                                #
+#---------------------------------------------------------------------------------#
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from mmdet.models.builder import HEADS
+
+from projects.mmdet3d_plugin.losses.grpo_loss import (
+    PlannerReward,
+    compute_group_advantages,
+    diagonal_gaussian_kl,
+    gaussian_log_prob,
+    group_relative_policy_loss,
+)
+from projects.mmdet3d_plugin.models.utils.lora import (
+    apply_lora_to_planning_head,
+    lora_parameters,
+    set_lora_enabled,
+)
+from .planning_head import PlanningHeadSingleMode
+
+
+@HEADS.register_module()
+class PlanningHeadGRPO(PlanningHeadSingleMode):
+    """Opt-in group-relative post-training for the UniAD planning head."""
+
+    def __init__(self, grpo=None, **kwargs):
+        grpo = {} if grpo is None else grpo
+        super().__init__(**kwargs)
+        defaults = dict(
+            num_samples=6,
+            kl_weight=0.01,
+            aux_weight=1.0,
+            lora_rank=8,
+            lora_alpha=16.0,
+            lora_dropout=0.0,
+            init_log_std=-1.5,
+            min_log_std=-5.0,
+            max_log_std=1.0,
+            ade_weight=1.0,
+            fde_weight=1.0,
+            comfort_weight=0.1,
+        )
+        defaults.update(grpo)
+        self.grpo_cfg = defaults
+
+        # The frozen SFT reference and trainable policy must see the same state.
+        # Disable the base decoder dropout for this opt-in post-training head.
+        for module in self.attn_module.modules():
+            if isinstance(module, nn.Dropout):
+                module.p = 0.0
+
+        apply_lora_to_planning_head(
+            self,
+            rank=defaults['lora_rank'],
+            alpha=defaults['lora_alpha'],
+            dropout=defaults['lora_dropout'],
+        )
+        self.log_std = nn.Parameter(torch.full(
+            (self.planning_steps, 2), defaults['init_log_std']))
+        self.reward_fn = PlannerReward(
+            planning_steps=self.planning_steps,
+            ade_weight=defaults['ade_weight'],
+            fde_weight=defaults['fde_weight'],
+            comfort_weight=defaults['comfort_weight'],
+        )
+
+    def _encode_plan_query(self, bev_embed, bev_pos, sdc_traj_query,
+                           sdc_track_query, command):
+        sdc_track_query = sdc_track_query.detach()
+        sdc_traj_query = sdc_traj_query[-1]
+        num_modes = sdc_traj_query.shape[1]
+        sdc_track_query = sdc_track_query[:, None].expand(
+            -1, num_modes, -1)
+        command = torch.as_tensor(
+            command, device=bev_embed.device, dtype=torch.long).reshape(-1)
+        navi_embed = self.navi_embed.weight[command]
+        navi_embed = navi_embed[:, None].expand(-1, num_modes, -1)
+
+        plan_query = torch.cat(
+            [sdc_traj_query, sdc_track_query, navi_embed], dim=-1)
+        plan_query = self.mlp_fuser(plan_query).max(1, keepdim=True)[0]
+        plan_query = rearrange(plan_query, 'b p c -> p b c')
+
+        bev_pos = rearrange(bev_pos, 'b c h w -> (h w) b c')
+        bev_feat = bev_embed + bev_pos
+        if self.with_adapter:
+            bev_feat = rearrange(
+                bev_feat, '(h w) b c -> b c h w',
+                h=self.bev_h, w=self.bev_w)
+            bev_feat = bev_feat + self.bev_adapter(bev_feat)
+            bev_feat = rearrange(bev_feat, 'b c h w -> (h w) b c')
+
+        plan_query = plan_query + self.pos_embed.weight[None]
+        return self.attn_module(plan_query, bev_feat)
+
+    def _mean_increments(self, plan_query):
+        return self.reg_branch(plan_query).view(
+            -1, self.planning_steps, 2)
+
+    def _policy_mean(self, bev_embed, bev_pos, sdc_traj_query,
+                     sdc_track_query, command):
+        query = self._encode_plan_query(
+            bev_embed, bev_pos, sdc_traj_query, sdc_track_query, command)
+        return self._mean_increments(query)
+
+    @staticmethod
+    def _positions(increments):
+        return torch.cumsum(increments, dim=-2)
+
+    def _sample_increments(self, mean):
+        log_std = self.log_std.clamp(
+            self.grpo_cfg['min_log_std'], self.grpo_cfg['max_log_std'])
+        noise = torch.randn(
+            mean.shape[0], self.grpo_cfg['num_samples'],
+            self.planning_steps, 2, device=mean.device, dtype=mean.dtype)
+        return mean[:, None] + log_std.exp()[None, None] * noise, log_std
+
+    def forward(self, bev_embed, occ_mask, bev_pos, sdc_traj_query,
+                sdc_track_query, command):
+        mean = self._policy_mean(
+            bev_embed, bev_pos, sdc_traj_query, sdc_track_query, command)
+        trajectory = self._positions(mean)
+        if self.use_col_optim and not self.training:
+            if occ_mask is None:
+                raise ValueError('occ_mask is required for collision optimization')
+            trajectory = self.collision_optimization(trajectory, occ_mask)
+        return dict(sdc_traj=trajectory, sdc_traj_all=trajectory)
+
+    def forward_train(self, bev_embed, outs_motion={}, sdc_planning=None,
+                      sdc_planning_mask=None, command=None,
+                      gt_future_boxes=None):
+        sdc_traj_query = outs_motion['sdc_traj_query']
+        sdc_track_query = outs_motion['sdc_track_query']
+        bev_pos = outs_motion['bev_pos']
+
+        mean = self._policy_mean(
+            bev_embed, bev_pos, sdc_traj_query, sdc_track_query, command)
+        increments, log_std = self._sample_increments(mean)
+        trajectories = self._positions(increments)
+
+        # Score-function gradients require fixed sampled actions.  Without the
+        # detach below, reparameterization cancels the mean-policy gradient.
+        log_prob = gaussian_log_prob(
+            increments.detach(), mean, log_std,
+            self.grpo_cfg['min_log_std'], self.grpo_cfg['max_log_std'])
+        with torch.no_grad():
+            set_lora_enabled(self, False)
+            try:
+                reference_mean = self._policy_mean(
+                    bev_embed, bev_pos, sdc_traj_query,
+                    sdc_track_query, command)
+            finally:
+                set_lora_enabled(self, True)
+
+            reward, metrics = self.reward_fn(
+                trajectories, sdc_planning, sdc_planning_mask)
+            advantages = compute_group_advantages(reward)
+
+        loss_grpo = group_relative_policy_loss(log_prob, advantages)
+        kl = diagonal_gaussian_kl(mean, reference_mean, log_std)
+        mean_trajectory = self._positions(mean)
+        target = sdc_planning[..., :self.planning_steps, :2]
+        mask = torch.any(
+            sdc_planning_mask[..., :self.planning_steps], dim=-1)
+        if target.dim() == 4:
+            target = target[:, 0]
+            mask = mask[:, 0]
+        loss_aux = self.loss_planning(mean_trajectory, target, mask)
+
+        losses = dict(
+            loss_grpo=loss_grpo,
+            loss_kl=kl * self.grpo_cfg['kl_weight'],
+            loss_ade=loss_aux * self.grpo_cfg['aux_weight'],
+            kl=kl.detach(),
+            mean_path_ade=loss_aux.detach(),
+            **metrics,
+        )
+        outputs = dict(
+            sdc_traj=mean_trajectory,
+            sdc_traj_all=mean_trajectory,
+            traj_samples=trajectories.detach(),
+        )
+        return dict(losses=losses, outs_motion=outputs)
+
+    def freeze_for_posttrain(self):
+        self.requires_grad_(False)
+        for parameter in lora_parameters(self):
+            parameter.requires_grad = True
+        self.log_std.requires_grad = True
+        if self.with_adapter:
+            self.bev_adapter.eval()

--- a/projects/mmdet3d_plugin/uniad/detectors/uniad_e2e.py
+++ b/projects/mmdet3d_plugin/uniad/detectors/uniad_e2e.py
@@ -31,6 +31,7 @@ class UniAD(UniADTrack):
             occ=1.0,
             planning=1.0
         ),
+        planner_posttrain_only=False,
         **kwargs,
     ):
         super(UniAD, self).__init__(**kwargs)
@@ -42,6 +43,15 @@ class UniAD(UniADTrack):
             self.motion_head = build_head(motion_head)
         if planning_head:
             self.planning_head = build_head(planning_head)
+
+        self.planner_posttrain_only = planner_posttrain_only
+        if planner_posttrain_only:
+            if not self.with_planning_head or not hasattr(
+                    self.planning_head, 'freeze_for_posttrain'):
+                raise ValueError(
+                    'planner_posttrain_only requires a post-training head')
+            self.requires_grad_(False)
+            self.planning_head.freeze_for_posttrain()
         
         self.task_loss_weight = task_loss_weight
         assert set(task_loss_weight.keys()) == \
@@ -162,8 +172,10 @@ class UniAD(UniADTrack):
 
         losses_track, outs_track = self.forward_track_train(img, gt_bboxes_3d, gt_labels_3d, gt_past_traj, gt_past_traj_mask, gt_inds, gt_sdc_bbox, gt_sdc_label,
                                                         l2g_t, l2g_r_mat, img_metas, timestamp)
-        losses_track = self.loss_weighted_and_prefixed(losses_track, prefix='track')
-        losses.update(losses_track)
+        if not self.planner_posttrain_only:
+            losses_track = self.loss_weighted_and_prefixed(
+                losses_track, prefix='track')
+            losses.update(losses_track)
         
         # Upsample bev for tiny version
         outs_track = self.upsample_bev_if_tiny(outs_track)
@@ -178,8 +190,10 @@ class UniAD(UniADTrack):
             losses_seg, outs_seg = self.seg_head.forward_train(bev_embed, img_metas,
                                                           gt_lane_labels, gt_lane_bboxes, gt_lane_masks)
             
-            losses_seg = self.loss_weighted_and_prefixed(losses_seg, prefix='map')
-            losses.update(losses_seg)
+            if not self.planner_posttrain_only:
+                losses_seg = self.loss_weighted_and_prefixed(
+                    losses_seg, prefix='map')
+                losses.update(losses_seg)
 
         outs_motion = dict()
         # Forward Motion Head
@@ -193,11 +207,13 @@ class UniAD(UniADTrack):
             losses_motion = ret_dict_motion["losses"]
             outs_motion = ret_dict_motion["outs_motion"]
             outs_motion['bev_pos'] = bev_pos
-            losses_motion = self.loss_weighted_and_prefixed(losses_motion, prefix='motion')
-            losses.update(losses_motion)
+            if not self.planner_posttrain_only:
+                losses_motion = self.loss_weighted_and_prefixed(
+                    losses_motion, prefix='motion')
+                losses.update(losses_motion)
 
         # Forward Occ Head
-        if self.with_occ_head:
+        if self.with_occ_head and not self.planner_posttrain_only:
             if outs_motion['track_query'].shape[1] == 0:
                 # TODO: rm hard code
                 outs_motion['track_query'] = torch.zeros((1, 1, 256)).to(bev_embed)

--- a/tests/test_planner_grpo.py
+++ b/tests/test_planner_grpo.py
@@ -1,0 +1,99 @@
+import copy
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+
+class _Registry:
+    def register_module(self):
+        return lambda cls: cls
+
+
+def _load(name, relative_path):
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(name, root / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Keep these core unit tests independent of an installed MMDetection stack.
+mmdet = types.ModuleType('mmdet')
+mmdet_models = types.ModuleType('mmdet.models')
+mmdet_models.LOSSES = _Registry()
+mmdet.models = mmdet_models
+sys.modules.setdefault('mmdet', mmdet)
+sys.modules.setdefault('mmdet.models', mmdet_models)
+
+grpo_loss = _load(
+    'grpo_loss', 'projects/mmdet3d_plugin/losses/grpo_loss.py')
+lora = _load('lora', 'projects/mmdet3d_plugin/models/utils/lora.py')
+compute_group_advantages = grpo_loss.compute_group_advantages
+diagonal_gaussian_kl = grpo_loss.diagonal_gaussian_kl
+gaussian_log_prob = grpo_loss.gaussian_log_prob
+group_relative_policy_loss = grpo_loss.group_relative_policy_loss
+LoRALinear = lora.LoRALinear
+
+
+def test_lora_starts_at_the_frozen_base():
+    base = nn.Linear(8, 4)
+    reference = copy.deepcopy(base)
+    adapter = LoRALinear(base, rank=2, alpha=4.0)
+    inputs = torch.randn(3, 8)
+    assert torch.equal(adapter(inputs), reference(inputs))
+    assert not adapter.base.weight.requires_grad
+
+
+def test_lora_off_recovers_base_after_update():
+    adapter = LoRALinear(nn.Linear(8, 4), rank=2, alpha=4.0)
+    adapter.lora_B.data.normal_()
+    inputs = torch.randn(3, 8)
+    adapter.enabled = False
+    assert torch.equal(adapter(inputs), adapter.base(inputs))
+
+
+def test_lora_merged_weight_supports_functional_callers():
+    adapter = LoRALinear(nn.Linear(8, 4), rank=2, alpha=4.0)
+    adapter.lora_B.data.normal_()
+    inputs = torch.randn(3, 8)
+    expected = torch.nn.functional.linear(inputs, adapter.weight, adapter.bias)
+    assert torch.allclose(adapter(inputs), expected, atol=1e-6)
+
+
+def test_lora_loads_original_linear_checkpoint_keys():
+    original = nn.Linear(8, 4)
+    adapter = LoRALinear(nn.Linear(8, 4), rank=2, alpha=4.0)
+    adapter.load_state_dict(original.state_dict(), strict=False)
+    assert torch.equal(adapter.base.weight, original.weight)
+    assert torch.equal(adapter.base.bias, original.bias)
+
+
+def test_group_advantages_are_centered_and_detached():
+    reward = torch.tensor([[1.0, 2.0, 4.0]], requires_grad=True)
+    advantages = compute_group_advantages(reward)
+    assert torch.allclose(advantages.mean(1), torch.zeros(1), atol=1e-6)
+    assert not advantages.requires_grad
+
+
+def test_detached_actions_give_policy_mean_gradient():
+    mean = torch.zeros(1, 2, 2, requires_grad=True)
+    actions = torch.tensor([[[[1.0, 0.0], [1.0, 0.0]],
+                             [[-0.25, 0.0], [-0.25, 0.0]]]])
+    advantages = torch.tensor([[1.0, -1.0]])
+    log_prob = gaussian_log_prob(actions.detach(), mean, torch.zeros(2, 2))
+    group_relative_policy_loss(log_prob, advantages).backward()
+    assert mean.grad is not None
+    assert mean.grad.abs().sum() > 0
+
+
+def test_exact_reference_kl_is_non_negative():
+    mean = torch.randn(2, 6, 2)
+    reference = torch.randn(2, 6, 2)
+    log_std = torch.full((6, 2), -1.5)
+    kl = diagonal_gaussian_kl(mean, reference, log_std)
+    assert kl >= 0
+    assert diagonal_gaussian_kl(mean, mean, log_std) == 0

--- a/tests/test_planner_grpo.py
+++ b/tests/test_planner_grpo.py
@@ -36,6 +36,8 @@ compute_group_advantages = grpo_loss.compute_group_advantages
 diagonal_gaussian_kl = grpo_loss.diagonal_gaussian_kl
 gaussian_log_prob = grpo_loss.gaussian_log_prob
 group_relative_policy_loss = grpo_loss.group_relative_policy_loss
+comfort_penalty = grpo_loss.comfort_penalty
+masked_fde = grpo_loss.masked_fde
 LoRALinear = lora.LoRALinear
 
 
@@ -77,6 +79,20 @@ def test_group_advantages_are_centered_and_detached():
     advantages = compute_group_advantages(reward)
     assert torch.allclose(advantages.mean(1), torch.zeros(1), atol=1e-6)
     assert not advantages.requires_grad
+
+
+def test_fde_is_zero_without_valid_future_steps():
+    trajectories = torch.full((1, 3, 6, 2), 10.0)
+    target = torch.zeros(1, 6, 2)
+    mask = torch.zeros(1, 6, dtype=torch.bool)
+    assert torch.equal(
+        masked_fde(trajectories, target, mask), torch.zeros(1, 3))
+
+
+def test_comfort_includes_origin_to_first_waypoint():
+    trajectories = torch.zeros(1, 1, 6, 2)
+    trajectories[..., 0] = 10.0
+    assert comfort_penalty(trajectories).item() > 0
 
 
 def test_detached_actions_give_policy_mean_gradient():


### PR DESCRIPTION
## Summary

- add an opt-in `PlanningHeadGRPO` with LoRA adapters and Gaussian displacement rollouts
- freeze stage-2 UniAD when `planner_posttrain_only=True`; the default `PlanningHeadSingleMode` path is unchanged
- use detached-action group-relative policy gradients and exact non-negative reference KL
- include one config, focused tests, and scoped nuScenes v1.0-mini evidence

## Validation

- `9 passed` in `tests/test_planner_grpo.py`
- synthetic planner forward/backward gives non-zero LoRA-B and `log_std` gradients
- official `uniad_base_e2e.pth` planner weights load with no missing wrapped base weights
- MMCV config parsing passes

## Preliminary evidence

On 12 nuScenes v1.0-mini open-loop frames, the earlier LoRA/auxiliary-fit campaign reached 3.60 m mean / 0.98 m median deterministic mean-path ADE. Best logged rollout minFDE was 0.052 m. The earlier campaign's PPO term was inactive; these values are therefore not presented as a GRPO gain. No trainval or closed-loop claim is made.